### PR TITLE
Numbering in definition lists

### DIFF
--- a/tests/test_numbering.py
+++ b/tests/test_numbering.py
@@ -1,7 +1,7 @@
 # This Python file uses the following encoding: utf-8
 
 from unittest import TestCase
-from pandocfilters import Para, Str, Space, Span, Strong, RawInline, Emph, Header
+from pandocfilters import Para, Str, Space, Span, Strong, RawInline, Emph, Header, DefinitionList, Plain
 
 import json
 
@@ -72,6 +72,37 @@ def test_numbering():
         )
     ])
 
+    assert pandoc_numbering.numbering(src['t'], src['c'], '', {}) == dest
+
+def test_numbering_definitionlist():
+    init()
+
+    src = DefinitionList([
+        [
+            createListStr(u'Exercise #'),
+            [Plain([createListStr(u'Content A')])]
+        ],
+        [
+            createListStr(u'Exercise #'),
+            [Plain([createListStr(u'Content B')])]
+        ]
+    ])
+    dest = DefinitionList([
+        [
+            [Span(
+                [u'exercise:1', ['pandoc-numbering-text', 'exercise'], []],
+                [Strong(createListStr(u'Exercise 1'))]
+            )],
+            [Plain([createListStr(u'Content A')])]
+        ],
+        [
+            [Span(
+                [u'exercise:2', ['pandoc-numbering-text', 'exercise'], []],
+                [Strong(createListStr(u'Exercise 2'))]
+            )],
+            [Plain([createListStr(u'Content B')])]
+        ]
+    ])
     assert pandoc_numbering.numbering(src['t'], src['c'], '', {}) == dest
 
 def test_numbering_prefix_single():
@@ -396,4 +427,3 @@ def test_format():
     ])))
 
     json.loads(json.dumps(pandoc_numbering.numbering(src['t'], src['c'], '', meta))) == dest
-

--- a/tests/test_numbering.py
+++ b/tests/test_numbering.py
@@ -61,6 +61,14 @@ def getMeta5():
         ])
     }
 
+def test_numbering_none():
+    init()
+
+    src =  Para(createListStr(u'Not an exercise'))
+    dest = src
+
+    assert pandoc_numbering.numbering(src['t'], src['c'], '', {}) == dest
+
 def test_numbering():
     init()
 


### PR DESCRIPTION
I've created a fork of pandoc-numbering that adds support for numbering in definition lists. For example, it correctly handles markdown input like this:

~~~
Exercise #ex:first
 ~  This is the first exercise.

Exercise #ex:second
 ~  This is the second exercise. See [](#ex:first).
~~~

One reason this is useful is because the definition list logically encapsulates the caption "Exercise 1" together with the following content (typically the statement of the exercise, theorem, etc.). This makes it easier to customize the appearance of the output (for example, with CSS) and it is also helpful for combining with other pandoc filters.

I hope you agree that this is useful.

Best,
Jeff

ps. This is my very first pull request on GitHub, so thanks for being patient with anything that may be weird about it!